### PR TITLE
Remove configuration for disabling user indexes in MZ

### DIFF
--- a/go/api/openapi.yaml
+++ b/go/api/openapi.yaml
@@ -573,7 +573,6 @@ components:
         storageMb: 80174
         releaseTrack: ""
         id: id
-        disableUserIndexes: false
         status: status
       properties:
         id:
@@ -611,9 +610,6 @@ components:
           maximum: 1000000
           minimum: 100
           type: integer
-        disableUserIndexes:
-          default: false
-          type: boolean
         materializedExtraArgs:
           items:
             maxLength: 4096
@@ -642,7 +638,6 @@ components:
       - catalogRestoreMode
       - cloudProviderRegion
       - clusterId
-      - disableUserIndexes
       - enableTailscale
       - flaggedForDeletion
       - flaggedForUpdate
@@ -668,7 +663,6 @@ components:
         name: name
         storageMb: 80174
         releaseTrack: ""
-        disableUserIndexes: false
         mzVersion: mzVersion
         enableTailscale: false
         tailscaleAuthKey: tailscaleAuthKey
@@ -689,9 +683,6 @@ components:
           maximum: 1000000
           minimum: 100
           type: integer
-        disableUserIndexes:
-          default: false
-          type: boolean
         materializedExtraArgs:
           items:
             maxLength: 4096
@@ -734,7 +725,6 @@ components:
         size: ""
         catalogRestoreMode: ""
         name: ""
-        disableUserIndexes: ""
         clusterId: ""
         mzVersion: ""
         enableTailscale: ""
@@ -762,10 +752,6 @@ components:
         size:
           allOf:
           - $ref: '#/components/schemas/ModifiedSize'
-          readOnly: true
-        disableUserIndexes:
-          allOf:
-          - $ref: '#/components/schemas/ModifiedBoolean'
           readOnly: true
         materializedExtraArgs:
           allOf:
@@ -798,7 +784,6 @@ components:
           size: ""
           catalogRestoreMode: ""
           name: ""
-          disableUserIndexes: ""
           clusterId: ""
           mzVersion: ""
           enableTailscale: ""
@@ -924,7 +909,6 @@ components:
         name: name
         storageMb: 80174
         releaseTrack: ""
-        disableUserIndexes: false
         mzVersion: mzVersion
         enableTailscale: false
         tailscaleAuthKey: tailscaleAuthKey
@@ -943,9 +927,6 @@ components:
           maximum: 1000000
           minimum: 100
           type: integer
-        disableUserIndexes:
-          default: false
-          type: boolean
         materializedExtraArgs:
           items:
             maxLength: 4096

--- a/go/model_deployment.go
+++ b/go/model_deployment.go
@@ -26,7 +26,6 @@ type Deployment struct {
 	CatalogRestoreMode bool `json:"catalogRestoreMode"`
 	Size DeploymentSizeEnum `json:"size"`
 	StorageMb int32 `json:"storageMb"`
-	DisableUserIndexes bool `json:"disableUserIndexes"`
 	MaterializedExtraArgs []string `json:"materializedExtraArgs"`
 	ClusterId NullableString `json:"clusterId"`
 	MzVersion string `json:"mzVersion"`
@@ -40,7 +39,7 @@ type Deployment struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewDeployment(id string, organization string, tlsAuthority NullableString, name string, hostname NullableString, flaggedForDeletion bool, flaggedForUpdate bool, catalogRestoreMode bool, size DeploymentSizeEnum, storageMb int32, disableUserIndexes bool, materializedExtraArgs []string, clusterId NullableString, mzVersion string, releaseTrack ReleaseTrackEnum, status string, enableTailscale bool, cloudProviderRegion SupportedCloudRegion) *Deployment {
+func NewDeployment(id string, organization string, tlsAuthority NullableString, name string, hostname NullableString, flaggedForDeletion bool, flaggedForUpdate bool, catalogRestoreMode bool, size DeploymentSizeEnum, storageMb int32, materializedExtraArgs []string, clusterId NullableString, mzVersion string, releaseTrack ReleaseTrackEnum, status string, enableTailscale bool, cloudProviderRegion SupportedCloudRegion) *Deployment {
 	this := Deployment{}
 	this.Id = id
 	this.Organization = organization
@@ -52,7 +51,6 @@ func NewDeployment(id string, organization string, tlsAuthority NullableString, 
 	this.CatalogRestoreMode = catalogRestoreMode
 	this.Size = size
 	this.StorageMb = storageMb
-	this.DisableUserIndexes = disableUserIndexes
 	this.MaterializedExtraArgs = materializedExtraArgs
 	this.ClusterId = clusterId
 	this.MzVersion = mzVersion
@@ -72,8 +70,6 @@ func NewDeploymentWithDefaults() *Deployment {
 	this.CatalogRestoreMode = catalogRestoreMode
 	var storageMb int32 = 100
 	this.StorageMb = storageMb
-	var disableUserIndexes bool = false
-	this.DisableUserIndexes = disableUserIndexes
 	var enableTailscale bool = false
 	this.EnableTailscale = enableTailscale
 	return &this
@@ -323,30 +319,6 @@ func (o *Deployment) SetStorageMb(v int32) {
 	o.StorageMb = v
 }
 
-// GetDisableUserIndexes returns the DisableUserIndexes field value
-func (o *Deployment) GetDisableUserIndexes() bool {
-	if o == nil {
-		var ret bool
-		return ret
-	}
-
-	return o.DisableUserIndexes
-}
-
-// GetDisableUserIndexesOk returns a tuple with the DisableUserIndexes field value
-// and a boolean to check if the value has been set.
-func (o *Deployment) GetDisableUserIndexesOk() (*bool, bool) {
-	if o == nil  {
-		return nil, false
-	}
-	return &o.DisableUserIndexes, true
-}
-
-// SetDisableUserIndexes sets field value
-func (o *Deployment) SetDisableUserIndexes(v bool) {
-	o.DisableUserIndexes = v
-}
-
 // GetMaterializedExtraArgs returns the MaterializedExtraArgs field value
 func (o *Deployment) GetMaterializedExtraArgs() []string {
 	if o == nil {
@@ -548,9 +520,6 @@ func (o Deployment) MarshalJSON() ([]byte, error) {
 	}
 	if true {
 		toSerialize["storageMb"] = o.StorageMb
-	}
-	if true {
-		toSerialize["disableUserIndexes"] = o.DisableUserIndexes
 	}
 	if true {
 		toSerialize["materializedExtraArgs"] = o.MaterializedExtraArgs

--- a/go/model_deployment_request.go
+++ b/go/model_deployment_request.go
@@ -20,7 +20,6 @@ type DeploymentRequest struct {
 	CatalogRestoreMode *bool `json:"catalogRestoreMode,omitempty"`
 	Size *DeploymentSizeEnum `json:"size,omitempty"`
 	StorageMb *int32 `json:"storageMb,omitempty"`
-	DisableUserIndexes *bool `json:"disableUserIndexes,omitempty"`
 	MaterializedExtraArgs *[]string `json:"materializedExtraArgs,omitempty"`
 	MzVersion *string `json:"mzVersion,omitempty"`
 	ReleaseTrack *ReleaseTrackEnum `json:"releaseTrack,omitempty"`
@@ -39,8 +38,6 @@ func NewDeploymentRequest(cloudProviderRegion SupportedCloudRegionRequest) *Depl
 	this.CatalogRestoreMode = &catalogRestoreMode
 	var storageMb int32 = 100
 	this.StorageMb = &storageMb
-	var disableUserIndexes bool = false
-	this.DisableUserIndexes = &disableUserIndexes
 	var enableTailscale bool = false
 	this.EnableTailscale = &enableTailscale
 	this.CloudProviderRegion = cloudProviderRegion
@@ -56,8 +53,6 @@ func NewDeploymentRequestWithDefaults() *DeploymentRequest {
 	this.CatalogRestoreMode = &catalogRestoreMode
 	var storageMb int32 = 100
 	this.StorageMb = &storageMb
-	var disableUserIndexes bool = false
-	this.DisableUserIndexes = &disableUserIndexes
 	var enableTailscale bool = false
 	this.EnableTailscale = &enableTailscale
 	return &this
@@ -189,38 +184,6 @@ func (o *DeploymentRequest) HasStorageMb() bool {
 // SetStorageMb gets a reference to the given int32 and assigns it to the StorageMb field.
 func (o *DeploymentRequest) SetStorageMb(v int32) {
 	o.StorageMb = &v
-}
-
-// GetDisableUserIndexes returns the DisableUserIndexes field value if set, zero value otherwise.
-func (o *DeploymentRequest) GetDisableUserIndexes() bool {
-	if o == nil || o.DisableUserIndexes == nil {
-		var ret bool
-		return ret
-	}
-	return *o.DisableUserIndexes
-}
-
-// GetDisableUserIndexesOk returns a tuple with the DisableUserIndexes field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *DeploymentRequest) GetDisableUserIndexesOk() (*bool, bool) {
-	if o == nil || o.DisableUserIndexes == nil {
-		return nil, false
-	}
-	return o.DisableUserIndexes, true
-}
-
-// HasDisableUserIndexes returns a boolean if a field has been set.
-func (o *DeploymentRequest) HasDisableUserIndexes() bool {
-	if o != nil && o.DisableUserIndexes != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetDisableUserIndexes gets a reference to the given bool and assigns it to the DisableUserIndexes field.
-func (o *DeploymentRequest) SetDisableUserIndexes(v bool) {
-	o.DisableUserIndexes = &v
 }
 
 // GetMaterializedExtraArgs returns the MaterializedExtraArgs field value if set, zero value otherwise.
@@ -420,9 +383,6 @@ func (o DeploymentRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.StorageMb != nil {
 		toSerialize["storageMb"] = o.StorageMb
-	}
-	if o.DisableUserIndexes != nil {
-		toSerialize["disableUserIndexes"] = o.DisableUserIndexes
 	}
 	if o.MaterializedExtraArgs != nil {
 		toSerialize["materializedExtraArgs"] = o.MaterializedExtraArgs

--- a/go/model_historical_deployment_change.go
+++ b/go/model_historical_deployment_change.go
@@ -22,7 +22,6 @@ type HistoricalDeploymentChange struct {
 	FlaggedForUpdate *ModifiedBoolean `json:"flaggedForUpdate,omitempty"`
 	CatalogRestoreMode *ModifiedBoolean `json:"catalogRestoreMode,omitempty"`
 	Size *ModifiedSize `json:"size,omitempty"`
-	DisableUserIndexes *ModifiedBoolean `json:"disableUserIndexes,omitempty"`
 	MaterializedExtraArgs *ModifiedStringList `json:"materializedExtraArgs,omitempty"`
 	ClusterId *ModifiedString `json:"clusterId,omitempty"`
 	MzVersion *ModifiedString `json:"mzVersion,omitempty"`
@@ -238,38 +237,6 @@ func (o *HistoricalDeploymentChange) SetSize(v ModifiedSize) {
 	o.Size = &v
 }
 
-// GetDisableUserIndexes returns the DisableUserIndexes field value if set, zero value otherwise.
-func (o *HistoricalDeploymentChange) GetDisableUserIndexes() ModifiedBoolean {
-	if o == nil || o.DisableUserIndexes == nil {
-		var ret ModifiedBoolean
-		return ret
-	}
-	return *o.DisableUserIndexes
-}
-
-// GetDisableUserIndexesOk returns a tuple with the DisableUserIndexes field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *HistoricalDeploymentChange) GetDisableUserIndexesOk() (*ModifiedBoolean, bool) {
-	if o == nil || o.DisableUserIndexes == nil {
-		return nil, false
-	}
-	return o.DisableUserIndexes, true
-}
-
-// HasDisableUserIndexes returns a boolean if a field has been set.
-func (o *HistoricalDeploymentChange) HasDisableUserIndexes() bool {
-	if o != nil && o.DisableUserIndexes != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetDisableUserIndexes gets a reference to the given ModifiedBoolean and assigns it to the DisableUserIndexes field.
-func (o *HistoricalDeploymentChange) SetDisableUserIndexes(v ModifiedBoolean) {
-	o.DisableUserIndexes = &v
-}
-
 // GetMaterializedExtraArgs returns the MaterializedExtraArgs field value if set, zero value otherwise.
 func (o *HistoricalDeploymentChange) GetMaterializedExtraArgs() ModifiedStringList {
 	if o == nil || o.MaterializedExtraArgs == nil {
@@ -417,9 +384,6 @@ func (o HistoricalDeploymentChange) MarshalJSON() ([]byte, error) {
 	}
 	if o.Size != nil {
 		toSerialize["size"] = o.Size
-	}
-	if o.DisableUserIndexes != nil {
-		toSerialize["disableUserIndexes"] = o.DisableUserIndexes
 	}
 	if o.MaterializedExtraArgs != nil {
 		toSerialize["materializedExtraArgs"] = o.MaterializedExtraArgs

--- a/go/model_patched_deployment_update_request.go
+++ b/go/model_patched_deployment_update_request.go
@@ -20,7 +20,6 @@ type PatchedDeploymentUpdateRequest struct {
 	CatalogRestoreMode *bool `json:"catalogRestoreMode,omitempty"`
 	Size *DeploymentSizeEnum `json:"size,omitempty"`
 	StorageMb *int32 `json:"storageMb,omitempty"`
-	DisableUserIndexes *bool `json:"disableUserIndexes,omitempty"`
 	MaterializedExtraArgs *[]string `json:"materializedExtraArgs,omitempty"`
 	MzVersion *string `json:"mzVersion,omitempty"`
 	ReleaseTrack *ReleaseTrackEnum `json:"releaseTrack,omitempty"`
@@ -38,8 +37,6 @@ func NewPatchedDeploymentUpdateRequest() *PatchedDeploymentUpdateRequest {
 	this.CatalogRestoreMode = &catalogRestoreMode
 	var storageMb int32 = 100
 	this.StorageMb = &storageMb
-	var disableUserIndexes bool = false
-	this.DisableUserIndexes = &disableUserIndexes
 	var enableTailscale bool = false
 	this.EnableTailscale = &enableTailscale
 	return &this
@@ -54,8 +51,6 @@ func NewPatchedDeploymentUpdateRequestWithDefaults() *PatchedDeploymentUpdateReq
 	this.CatalogRestoreMode = &catalogRestoreMode
 	var storageMb int32 = 100
 	this.StorageMb = &storageMb
-	var disableUserIndexes bool = false
-	this.DisableUserIndexes = &disableUserIndexes
 	var enableTailscale bool = false
 	this.EnableTailscale = &enableTailscale
 	return &this
@@ -187,38 +182,6 @@ func (o *PatchedDeploymentUpdateRequest) HasStorageMb() bool {
 // SetStorageMb gets a reference to the given int32 and assigns it to the StorageMb field.
 func (o *PatchedDeploymentUpdateRequest) SetStorageMb(v int32) {
 	o.StorageMb = &v
-}
-
-// GetDisableUserIndexes returns the DisableUserIndexes field value if set, zero value otherwise.
-func (o *PatchedDeploymentUpdateRequest) GetDisableUserIndexes() bool {
-	if o == nil || o.DisableUserIndexes == nil {
-		var ret bool
-		return ret
-	}
-	return *o.DisableUserIndexes
-}
-
-// GetDisableUserIndexesOk returns a tuple with the DisableUserIndexes field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *PatchedDeploymentUpdateRequest) GetDisableUserIndexesOk() (*bool, bool) {
-	if o == nil || o.DisableUserIndexes == nil {
-		return nil, false
-	}
-	return o.DisableUserIndexes, true
-}
-
-// HasDisableUserIndexes returns a boolean if a field has been set.
-func (o *PatchedDeploymentUpdateRequest) HasDisableUserIndexes() bool {
-	if o != nil && o.DisableUserIndexes != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetDisableUserIndexes gets a reference to the given bool and assigns it to the DisableUserIndexes field.
-func (o *PatchedDeploymentUpdateRequest) SetDisableUserIndexes(v bool) {
-	o.DisableUserIndexes = &v
 }
 
 // GetMaterializedExtraArgs returns the MaterializedExtraArgs field value if set, zero value otherwise.
@@ -394,9 +357,6 @@ func (o PatchedDeploymentUpdateRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.StorageMb != nil {
 		toSerialize["storageMb"] = o.StorageMb
-	}
-	if o.DisableUserIndexes != nil {
-		toSerialize["disableUserIndexes"] = o.DisableUserIndexes
 	}
 	if o.MaterializedExtraArgs != nil {
 		toSerialize["materializedExtraArgs"] = o.MaterializedExtraArgs

--- a/python/mzcloud/models/deployment.py
+++ b/python/mzcloud/models/deployment.py
@@ -22,7 +22,6 @@ class Deployment:
         catalog_restore_mode (bool):
         size (DeploymentSizeEnum):  Default: DeploymentSizeEnum.XS.
         storage_mb (int):  Default: 100.
-        disable_user_indexes (bool):
         materialized_extra_args (List[str]):
         mz_version (str):
         release_track (ReleaseTrackEnum):  Default: ReleaseTrackEnum.STABLE.
@@ -49,7 +48,6 @@ class Deployment:
     catalog_restore_mode: bool = False
     size: DeploymentSizeEnum = DeploymentSizeEnum.XS
     storage_mb: int = 100
-    disable_user_indexes: bool = False
     release_track: ReleaseTrackEnum = ReleaseTrackEnum.STABLE
     enable_tailscale: bool = False
     additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
@@ -64,7 +62,6 @@ class Deployment:
         size = self.size.value
 
         storage_mb = self.storage_mb
-        disable_user_indexes = self.disable_user_indexes
         materialized_extra_args = self.materialized_extra_args
 
         mz_version = self.mz_version
@@ -90,7 +87,6 @@ class Deployment:
                 "catalogRestoreMode": catalog_restore_mode,
                 "size": size,
                 "storageMb": storage_mb,
-                "disableUserIndexes": disable_user_indexes,
                 "materializedExtraArgs": materialized_extra_args,
                 "mzVersion": mz_version,
                 "releaseTrack": release_track,
@@ -124,8 +120,6 @@ class Deployment:
 
         storage_mb = d.pop("storageMb")
 
-        disable_user_indexes = d.pop("disableUserIndexes")
-
         materialized_extra_args = cast(List[str], d.pop("materializedExtraArgs"))
 
         mz_version = d.pop("mzVersion")
@@ -153,7 +147,6 @@ class Deployment:
             catalog_restore_mode=catalog_restore_mode,
             size=size,
             storage_mb=storage_mb,
-            disable_user_indexes=disable_user_indexes,
             materialized_extra_args=materialized_extra_args,
             mz_version=mz_version,
             release_track=release_track,

--- a/python/mzcloud/models/deployment_request.py
+++ b/python/mzcloud/models/deployment_request.py
@@ -19,7 +19,6 @@ class DeploymentRequest:
         catalog_restore_mode (Union[Unset, bool]):
         size (Union[Unset, DeploymentSizeEnum]):  Default: DeploymentSizeEnum.XS.
         storage_mb (Union[Unset, int]):  Default: 100.
-        disable_user_indexes (Union[Unset, bool]):
         materialized_extra_args (Union[Unset, List[str]]):
         mz_version (Union[Unset, str]):
         release_track (Union[Unset, ReleaseTrackEnum]):  Default: ReleaseTrackEnum.STABLE.
@@ -32,7 +31,6 @@ class DeploymentRequest:
     catalog_restore_mode: Union[Unset, bool] = False
     size: Union[Unset, DeploymentSizeEnum] = DeploymentSizeEnum.XS
     storage_mb: Union[Unset, int] = 100
-    disable_user_indexes: Union[Unset, bool] = False
     materialized_extra_args: Union[Unset, List[str]] = UNSET
     mz_version: Union[Unset, str] = UNSET
     release_track: Union[Unset, ReleaseTrackEnum] = ReleaseTrackEnum.STABLE
@@ -50,7 +48,6 @@ class DeploymentRequest:
             size = self.size.value
 
         storage_mb = self.storage_mb
-        disable_user_indexes = self.disable_user_indexes
         materialized_extra_args: Union[Unset, List[str]] = UNSET
         if not isinstance(self.materialized_extra_args, Unset):
             materialized_extra_args = self.materialized_extra_args
@@ -78,8 +75,6 @@ class DeploymentRequest:
             field_dict["size"] = size
         if storage_mb is not UNSET:
             field_dict["storageMb"] = storage_mb
-        if disable_user_indexes is not UNSET:
-            field_dict["disableUserIndexes"] = disable_user_indexes
         if materialized_extra_args is not UNSET:
             field_dict["materializedExtraArgs"] = materialized_extra_args
         if mz_version is not UNSET:
@@ -111,8 +106,6 @@ class DeploymentRequest:
 
         storage_mb = d.pop("storageMb", UNSET)
 
-        disable_user_indexes = d.pop("disableUserIndexes", UNSET)
-
         materialized_extra_args = cast(List[str], d.pop("materializedExtraArgs", UNSET))
 
         mz_version = d.pop("mzVersion", UNSET)
@@ -134,7 +127,6 @@ class DeploymentRequest:
             catalog_restore_mode=catalog_restore_mode,
             size=size,
             storage_mb=storage_mb,
-            disable_user_indexes=disable_user_indexes,
             materialized_extra_args=materialized_extra_args,
             mz_version=mz_version,
             release_track=release_track,

--- a/python/mzcloud/models/historical_deployment_change.py
+++ b/python/mzcloud/models/historical_deployment_change.py
@@ -21,7 +21,6 @@ class HistoricalDeploymentChange:
         flagged_for_update (Union[Unset, ModifiedBoolean]):
         catalog_restore_mode (Union[Unset, ModifiedBoolean]):
         size (Union[Unset, ModifiedSize]):
-        disable_user_indexes (Union[Unset, ModifiedBoolean]):
         materialized_extra_args (Union[Unset, ModifiedStringList]):
         cluster_id (Union[Unset, ModifiedString]):
         mz_version (Union[Unset, ModifiedString]):
@@ -34,7 +33,6 @@ class HistoricalDeploymentChange:
     flagged_for_update: Union[Unset, ModifiedBoolean] = UNSET
     catalog_restore_mode: Union[Unset, ModifiedBoolean] = UNSET
     size: Union[Unset, ModifiedSize] = UNSET
-    disable_user_indexes: Union[Unset, ModifiedBoolean] = UNSET
     materialized_extra_args: Union[Unset, ModifiedStringList] = UNSET
     cluster_id: Union[Unset, ModifiedString] = UNSET
     mz_version: Union[Unset, ModifiedString] = UNSET
@@ -65,10 +63,6 @@ class HistoricalDeploymentChange:
         size: Union[Unset, Dict[str, Any]] = UNSET
         if not isinstance(self.size, Unset):
             size = self.size.to_dict()
-
-        disable_user_indexes: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.disable_user_indexes, Unset):
-            disable_user_indexes = self.disable_user_indexes.to_dict()
 
         materialized_extra_args: Union[Unset, Dict[str, Any]] = UNSET
         if not isinstance(self.materialized_extra_args, Unset):
@@ -101,8 +95,6 @@ class HistoricalDeploymentChange:
             field_dict["catalogRestoreMode"] = catalog_restore_mode
         if size is not UNSET:
             field_dict["size"] = size
-        if disable_user_indexes is not UNSET:
-            field_dict["disableUserIndexes"] = disable_user_indexes
         if materialized_extra_args is not UNSET:
             field_dict["materializedExtraArgs"] = materialized_extra_args
         if cluster_id is not UNSET:
@@ -159,13 +151,6 @@ class HistoricalDeploymentChange:
         else:
             size = ModifiedSize.from_dict(_size)
 
-        _disable_user_indexes = d.pop("disableUserIndexes", UNSET)
-        disable_user_indexes: Union[Unset, ModifiedBoolean]
-        if isinstance(_disable_user_indexes, Unset):
-            disable_user_indexes = UNSET
-        else:
-            disable_user_indexes = ModifiedBoolean.from_dict(_disable_user_indexes)
-
         _materialized_extra_args = d.pop("materializedExtraArgs", UNSET)
         materialized_extra_args: Union[Unset, ModifiedStringList]
         if isinstance(_materialized_extra_args, Unset):
@@ -201,7 +186,6 @@ class HistoricalDeploymentChange:
             flagged_for_update=flagged_for_update,
             catalog_restore_mode=catalog_restore_mode,
             size=size,
-            disable_user_indexes=disable_user_indexes,
             materialized_extra_args=materialized_extra_args,
             cluster_id=cluster_id,
             mz_version=mz_version,

--- a/python/mzcloud/models/patched_deployment_update_request.py
+++ b/python/mzcloud/models/patched_deployment_update_request.py
@@ -17,7 +17,6 @@ class PatchedDeploymentUpdateRequest:
         catalog_restore_mode (Union[Unset, bool]):
         size (Union[Unset, DeploymentSizeEnum]):  Default: DeploymentSizeEnum.XS.
         storage_mb (Union[Unset, int]):  Default: 100.
-        disable_user_indexes (Union[Unset, bool]):
         materialized_extra_args (Union[Unset, List[str]]):
         mz_version (Union[Unset, str]):
         release_track (Union[Unset, ReleaseTrackEnum]):  Default: ReleaseTrackEnum.STABLE.
@@ -29,7 +28,6 @@ class PatchedDeploymentUpdateRequest:
     catalog_restore_mode: Union[Unset, bool] = False
     size: Union[Unset, DeploymentSizeEnum] = DeploymentSizeEnum.XS
     storage_mb: Union[Unset, int] = 100
-    disable_user_indexes: Union[Unset, bool] = False
     materialized_extra_args: Union[Unset, List[str]] = UNSET
     mz_version: Union[Unset, str] = UNSET
     release_track: Union[Unset, ReleaseTrackEnum] = ReleaseTrackEnum.STABLE
@@ -45,7 +43,6 @@ class PatchedDeploymentUpdateRequest:
             size = self.size.value
 
         storage_mb = self.storage_mb
-        disable_user_indexes = self.disable_user_indexes
         materialized_extra_args: Union[Unset, List[str]] = UNSET
         if not isinstance(self.materialized_extra_args, Unset):
             materialized_extra_args = self.materialized_extra_args
@@ -69,8 +66,6 @@ class PatchedDeploymentUpdateRequest:
             field_dict["size"] = size
         if storage_mb is not UNSET:
             field_dict["storageMb"] = storage_mb
-        if disable_user_indexes is not UNSET:
-            field_dict["disableUserIndexes"] = disable_user_indexes
         if materialized_extra_args is not UNSET:
             field_dict["materializedExtraArgs"] = materialized_extra_args
         if mz_version is not UNSET:
@@ -100,8 +95,6 @@ class PatchedDeploymentUpdateRequest:
 
         storage_mb = d.pop("storageMb", UNSET)
 
-        disable_user_indexes = d.pop("disableUserIndexes", UNSET)
-
         materialized_extra_args = cast(List[str], d.pop("materializedExtraArgs", UNSET))
 
         mz_version = d.pop("mzVersion", UNSET)
@@ -122,7 +115,6 @@ class PatchedDeploymentUpdateRequest:
             catalog_restore_mode=catalog_restore_mode,
             size=size,
             storage_mb=storage_mb,
-            disable_user_indexes=disable_user_indexes,
             materialized_extra_args=materialized_extra_args,
             mz_version=mz_version,
             release_track=release_track,

--- a/rust/src/models/deployment.rs
+++ b/rust/src/models/deployment.rs
@@ -30,8 +30,6 @@ pub struct Deployment {
     pub size: Box<crate::models::DeploymentSizeEnum>,
     #[serde(rename = "storageMb")]
     pub storage_mb: i32,
-    #[serde(rename = "disableUserIndexes")]
-    pub disable_user_indexes: bool,
     #[serde(rename = "materializedExtraArgs")]
     pub materialized_extra_args: Vec<String>,
     #[serde(rename = "clusterId")]
@@ -60,7 +58,6 @@ impl Deployment {
         catalog_restore_mode: bool,
         size: crate::models::DeploymentSizeEnum,
         storage_mb: i32,
-        disable_user_indexes: bool,
         materialized_extra_args: Vec<String>,
         cluster_id: Option<String>,
         mz_version: String,
@@ -80,7 +77,6 @@ impl Deployment {
             catalog_restore_mode,
             size: Box::new(size),
             storage_mb,
-            disable_user_indexes,
             materialized_extra_args,
             cluster_id,
             mz_version,

--- a/rust/src/models/deployment_request.rs
+++ b/rust/src/models/deployment_request.rs
@@ -18,8 +18,6 @@ pub struct DeploymentRequest {
     pub size: Option<Box<crate::models::DeploymentSizeEnum>>,
     #[serde(rename = "storageMb", skip_serializing_if = "Option::is_none")]
     pub storage_mb: Option<i32>,
-    #[serde(rename = "disableUserIndexes", skip_serializing_if = "Option::is_none")]
-    pub disable_user_indexes: Option<bool>,
     #[serde(
         rename = "materializedExtraArgs",
         skip_serializing_if = "Option::is_none"
@@ -46,7 +44,6 @@ impl DeploymentRequest {
             catalog_restore_mode: None,
             size: None,
             storage_mb: None,
-            disable_user_indexes: None,
             materialized_extra_args: None,
             mz_version: None,
             release_track: None,

--- a/rust/src/models/historical_deployment_change.rs
+++ b/rust/src/models/historical_deployment_change.rs
@@ -22,8 +22,6 @@ pub struct HistoricalDeploymentChange {
     pub catalog_restore_mode: Option<Box<crate::models::ModifiedBoolean>>,
     #[serde(rename = "size", skip_serializing_if = "Option::is_none")]
     pub size: Option<Box<crate::models::ModifiedSize>>,
-    #[serde(rename = "disableUserIndexes", skip_serializing_if = "Option::is_none")]
-    pub disable_user_indexes: Option<Box<crate::models::ModifiedBoolean>>,
     #[serde(
         rename = "materializedExtraArgs",
         skip_serializing_if = "Option::is_none"
@@ -46,7 +44,6 @@ impl HistoricalDeploymentChange {
             flagged_for_update: None,
             catalog_restore_mode: None,
             size: None,
-            disable_user_indexes: None,
             materialized_extra_args: None,
             cluster_id: None,
             mz_version: None,

--- a/rust/src/models/patched_deployment_update_request.rs
+++ b/rust/src/models/patched_deployment_update_request.rs
@@ -18,8 +18,6 @@ pub struct PatchedDeploymentUpdateRequest {
     pub size: Option<Box<crate::models::DeploymentSizeEnum>>,
     #[serde(rename = "storageMb", skip_serializing_if = "Option::is_none")]
     pub storage_mb: Option<i32>,
-    #[serde(rename = "disableUserIndexes", skip_serializing_if = "Option::is_none")]
-    pub disable_user_indexes: Option<bool>,
     #[serde(
         rename = "materializedExtraArgs",
         skip_serializing_if = "Option::is_none"
@@ -42,7 +40,6 @@ impl PatchedDeploymentUpdateRequest {
             catalog_restore_mode: None,
             size: None,
             storage_mb: None,
-            disable_user_indexes: None,
             materialized_extra_args: None,
             mz_version: None,
             release_track: None,

--- a/schema.yml
+++ b/schema.yml
@@ -557,9 +557,6 @@ components:
           maximum: 1000000
           minimum: 100
           default: 100
-        disableUserIndexes:
-          type: boolean
-          default: false
         materializedExtraArgs:
           type: array
           items:
@@ -589,7 +586,6 @@ components:
       - catalogRestoreMode
       - cloudProviderRegion
       - clusterId
-      - disableUserIndexes
       - enableTailscale
       - flaggedForDeletion
       - flaggedForUpdate
@@ -622,9 +618,6 @@ components:
           maximum: 1000000
           minimum: 100
           default: 100
-        disableUserIndexes:
-          type: boolean
-          default: false
         materializedExtraArgs:
           type: array
           items:
@@ -684,10 +677,6 @@ components:
         size:
           allOf:
           - $ref: '#/components/schemas/ModifiedSize'
-          readOnly: true
-        disableUserIndexes:
-          allOf:
-          - $ref: '#/components/schemas/ModifiedBoolean'
           readOnly: true
         materializedExtraArgs:
           allOf:
@@ -828,9 +817,6 @@ components:
           maximum: 1000000
           minimum: 100
           default: 100
-        disableUserIndexes:
-          type: boolean
-          default: false
         materializedExtraArgs:
           type: array
           items:


### PR DESCRIPTION
This is going away as part of MaterializeInc/materialize#12412, so I science dogged removing the option from this repo, as well. Please holler if I've mangled anything and let me know how to run local tests (found `bin/gen` but can't get python to work).